### PR TITLE
Configure Vercel output directory for app build

### DIFF
--- a/app/src/components/BrandMark.test.tsx
+++ b/app/src/components/BrandMark.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import * as matchers from '@testing-library/jest-dom/matchers'

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "app/dist"
+}


### PR DESCRIPTION
## Summary
- configure Vercel to use the app's built files under `app/dist`
- fix BrandMark test by importing React

## Testing
- `npm run build`
- `CI=1 npx vitest run --config app/vitest.config.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f80b31348323bcda8da44aa3e77f