### PR TITLE
Wire home button to dashboard and show resource summaries

### DIFF
--- a/app/src/pages/Dashboard.test.tsx
+++ b/app/src/pages/Dashboard.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import Dashboard from './Dashboard'
+
+expect.extend(matchers)
+
+describe('Dashboard', () => {
+  it('displays resource titles', () => {
+    render(<Dashboard />)
+    expect(
+      screen.getByText(
+        /The Phoenix Plan: A Strategic Guide to Financial Recovery/i
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /The Architecture of Financial Transformation/i
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,8 +1,30 @@
+const resources = [
+  {
+    title:
+      'The Phoenix Plan: A Strategic Guide to Financial Recovery, Credit Dominance, and Wealth Creation',
+    description:
+      'Step-by-step playbook to stabilize cash flow, address wage garnishment, and build a resilient financial foundation.',
+  },
+  {
+    title:
+      'The Architecture of Financial Transformation: A Holistic Plan for Stability, Growth, and Personal Success',
+    description:
+      'Comprehensive blueprint for creating order, eliminating debt, and cultivating long-term wealth.',
+  },
+]
+
 export default function Dashboard() {
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Dashboard</h1>
-      <p>Coming soon.</p>
+      <ul className="space-y-4 text-left max-w-prose">
+        {resources.map((r) => (
+          <li key={r.title} className="border rounded p-4">
+            <h2 className="font-semibold">{r.title}</h2>
+            <p className="text-sm text-gray-700 dark:text-gray-300">{r.description}</p>
+          </li>
+        ))}
+      </ul>
     </main>
   )
 }

--- a/app/src/pages/Home.test.tsx
+++ b/app/src/pages/Home.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+import Home from './Home'
+
+expect.extend(matchers)
+
+describe('Home', () => {
+  it('navigates to dashboard on get started', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/dashboard" element={<div>Dashboard page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    expect(screen.getByText(/dashboard page/i)).toBeInTheDocument()
+  })
+})

--- a/app/src/pages/Home.tsx
+++ b/app/src/pages/Home.tsx
@@ -1,11 +1,13 @@
 import { Button } from '../components/ui/Button'
+import { useNavigate } from 'react-router-dom'
 
 export default function Home() {
+  const navigate = useNavigate()
   return (
     <main className="p-4 text-center space-y-4">
       <h1 className="text-3xl font-bold">From ashes to assets</h1>
       <p className="text-gray-600 dark:text-gray-300">Welcome to Fynix.</p>
-      <Button>Get Started</Button>
+      <Button onClick={() => navigate('/dashboard')}>Get Started</Button>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- navigate to the dashboard when the home page Get Started button is pressed
- show key resource summaries on the dashboard
- add tests for navigation and resource display

## Testing
- `npm test --workspace app -- --run`
- `npm run lint --workspace app`

------
https://chatgpt.com/codex/tasks/task_e_68a91288cf108323a557169d06c3018a