### PR TITLE
Add unit and E2E tests for utilities and routing

### DIFF
--- a/app/src/tools/__tests__/currency.test.ts
+++ b/app/src/tools/__tests__/currency.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { formatCurrency, parseCurrency } from '../currency'
+
+describe('currency utilities', () => {
+  it('formats numbers as USD currency', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56')
+  })
+
+  it('parses currency strings back to numbers', () => {
+    expect(parseCurrency('$1,234.56')).toBeCloseTo(1234.56)
+  })
+})

--- a/app/src/tools/currency.ts
+++ b/app/src/tools/currency.ts
@@ -1,0 +1,8 @@
+export function formatCurrency(value: number, locale = 'en-US', currency = 'USD'): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
+}
+
+export function parseCurrency(value: string): number {
+  const normalized = value.replace(/[^0-9.-]+/g, '')
+  return Number.parseFloat(normalized)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "app"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.45.0",
         "playwright": "^1.45.0"
       }
     },
@@ -1273,6 +1274,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "npm run build --workspace app",
     "lint": "npm run lint --workspace app",
-    "test": "npm test --workspace app"
+    "test": "npm test --workspace app -- --run && npx playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.45.0",
     "playwright": "^1.45.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev --workspace app',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+})

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+test('home page shows tagline and byline', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { level: 1, name: 'From ashes to assets' })).toBeVisible()
+  await expect(page.getByText('Welcome to Fynix.')).toBeVisible()
+})
+
+test('navigates to dashboard when clicking Get Started', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Get Started' }).click()
+  await expect(page).toHaveURL(/\/dashboard$/)
+  await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- add currency formatter utilities with Vitest specs
- add Playwright tests to confirm tagline, byline, and dashboard routing
- run Playwright and Vitest via existing `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9340acb008323986a7722db37a80e