### PR TITLE
feat: add state stores and query client provider

### DIFF
--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 
+const queryClient = new QueryClient()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/app/src/state/budget.ts
+++ b/app/src/state/budget.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+interface BudgetState {
+  income: number
+  expenses: number
+  setIncome: (income: number) => void
+  setExpenses: (expenses: number) => void
+}
+
+export const useBudgetStore = create<BudgetState>((set) => ({
+  income: 0,
+  expenses: 0,
+  setIncome: (income) => set({ income }),
+  setExpenses: (expenses) => set({ expenses })
+}))

--- a/app/src/state/credit.ts
+++ b/app/src/state/credit.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface CreditState {
+  score: number
+  setScore: (score: number) => void
+}
+
+export const useCreditStore = create<CreditState>((set) => ({
+  score: 0,
+  setScore: (score) => set({ score })
+}))

--- a/app/src/state/profile.ts
+++ b/app/src/state/profile.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand'
+
+export interface Profile {
+  name: string
+  email: string
+}
+
+interface ProfileState {
+  profile: Profile | null
+  setProfile: (profile: Profile) => void
+}
+
+export const useProfileStore = create<ProfileState>((set) => ({
+  profile: null,
+  setProfile: (profile) => set({ profile })
+}))


### PR DESCRIPTION
## Summary
- scaffold profile, budget, and credit stores using Zustand
- wrap application with QueryClientProvider for upcoming async features

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a9340bd74083238e8f7d43f3d6bd66