### PR TITLE
feat: add finance tools and utilities

### DIFF
--- a/app/src/lib/finance.test.ts
+++ b/app/src/lib/finance.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { calculateBudget, calculateGarnishment } from './finance'
+
+describe('finance utilities', () => {
+  it('calculates budget summary', () => {
+    const result = calculateBudget(5000, { rent: 1000, food: 500 })
+    expect(result.totalIncome).toBe(5000)
+    expect(result.totalExpenses).toBe(1500)
+    expect(result.disposableIncome).toBe(3500)
+  })
+
+  it('calculates wage garnishment', () => {
+    const result = calculateGarnishment({ income: 4000, garnishmentRate: 0.25 })
+    expect(result.garnishment).toBe(1000)
+    expect(result.remainingIncome).toBe(3000)
+  })
+})

--- a/app/src/lib/finance.ts
+++ b/app/src/lib/finance.ts
@@ -1,0 +1,28 @@
+export function calculateBudget(
+  income: number,
+  expenses: Record<string, number>
+) {
+  const totalExpenses = Object.values(expenses).reduce(
+    (sum, n) => sum + n,
+    0
+  )
+  return {
+    totalIncome: income,
+    totalExpenses,
+    disposableIncome: income - totalExpenses,
+  }
+}
+
+export function calculateGarnishment({
+  income,
+  garnishmentRate,
+}: {
+  income: number
+  garnishmentRate: number
+}) {
+  const garnishment = income * garnishmentRate
+  return {
+    garnishment,
+    remainingIncome: income - garnishment,
+  }
+}

--- a/app/src/tools/BudgetPlanner.tsx
+++ b/app/src/tools/BudgetPlanner.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react'
+import { PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { ChartContainer } from '../components/ui/ChartContainer'
+import { calculateBudget } from '../lib/finance'
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042']
+
+export default function BudgetPlanner() {
+  const data = useMemo(() => {
+    const result = calculateBudget(5000, {
+      rent: 1500,
+      groceries: 500,
+      utilities: 200,
+    })
+    return [
+      { name: 'Rent', value: 1500 },
+      { name: 'Groceries', value: 500 },
+      { name: 'Utilities', value: 200 },
+      { name: 'Remaining', value: result.disposableIncome },
+    ]
+  }, [])
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Budget Planner</h1>
+      <ChartContainer>
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="name" label>
+            {data.map((entry, index) => (
+              <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ChartContainer>
+    </main>
+  )
+}

--- a/app/src/tools/GarnishmentCalculator.tsx
+++ b/app/src/tools/GarnishmentCalculator.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts'
+import { ChartContainer } from '../components/ui/ChartContainer'
+import { calculateGarnishment } from '../lib/finance'
+
+export default function GarnishmentCalculator() {
+  const income = 4000
+  const rate = 0.25
+  const result = useMemo(
+    () => calculateGarnishment({ income, garnishmentRate: rate }),
+    [income, rate]
+  )
+  const data = [
+    { name: 'Income', value: income },
+    { name: 'Garnished', value: result.garnishment },
+    { name: 'Remaining', value: result.remainingIncome },
+  ]
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Garnishment Calculator</h1>
+      <ChartContainer>
+        <BarChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="value" fill="#8884d8" />
+        </BarChart>
+      </ChartContainer>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable finance calculation utilities
- add BudgetPlanner and GarnishmentCalculator tools with Recharts charts
- cover finance utilities with unit tests

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9340e6cc48323aa77c9e7946bca9a