### PR TITLE
Enhance docs page styling with Tailwind typography

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.1.10",

--- a/app/src/pages/Docs.tsx
+++ b/app/src/pages/Docs.tsx
@@ -77,7 +77,7 @@ export default function Docs() {
             ))}
           </ul>
         </nav>
-        <article className="prose max-w-none">
+        <article className="prose dark:prose-invert max-w-none prose-img:rounded-lg prose-img:shadow-md">
           <ReactMarkdown
             components={{
               h2: (props) => <Heading level={2} {...props} />,

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,8 +1,10 @@
 /** @type {import('tailwindcss').Config} */
+import typography from '@tailwindcss/typography'
+
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [typography],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.1.0",
         "@types/react": "^19.1.10",
@@ -1579,6 +1580,36 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.85.5",
@@ -4428,6 +4459,20 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {


### PR DESCRIPTION
## Summary
- import Tailwind Typography plugin for richer markdown formatting
- refine docs article styles with dark mode, rounded images and subtle shadows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9476b6f908323bb9e9f33cbfe9c06