### PR TITLE
Refine Supabase guards and disable PWA plugin

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,26 +1,59 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { supabase } from './supabase'
+import type { User } from '@supabase/supabase-js'
+import { hasSupabaseConfig, getSupabase } from './supabase'
 
-export type SessionUser = { id: string; email: string | null }
-
-const AuthCtx = createContext<{ user: SessionUser | null; loading: boolean }>({ user: null, loading: true })
-
-export function AuthProvider({ children }: { children: React.ReactNode }){
-  const [user, setUser] = useState<SessionUser | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => {
-      setUser(data.user ? { id: data.user.id, email: data.user.email ?? null } : null)
-      setLoading(false)
-    })
-    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
-      setUser(session?.user ? { id: session.user.id, email: session.user.email ?? null } : null)
-    })
-    return () => sub.subscription.unsubscribe()
-  }, [])
-
-  return <AuthCtx.Provider value={{ user, loading }}>{children}</AuthCtx.Provider>
+type AuthState = {
+  user: User | null
+  loading: boolean
+  enabled: boolean
+  signInWithOtp: (email: string) => Promise<void>
+  signOut: () => Promise<void>
 }
 
-export function useAuth(){ return useContext(AuthCtx) }
+const AuthCtx = createContext<AuthState>({
+  user: null,
+  loading: false,
+  enabled: false,
+  signInWithOtp: async () => {},
+  signOut: async () => {}
+})
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState<boolean>(hasSupabaseConfig)
+
+  useEffect(() => {
+    if (!hasSupabaseConfig) { setLoading(false); return }
+    const supabase = getSupabase()
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null)
+      setLoading(false)
+    })
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      // SDK shapes vary by version
+      // @ts-expect-error
+      sub?.subscription?.unsubscribe?.() ?? sub?.unsubscribe?.()
+    }
+  }, [])
+
+  const signInWithOtp = async (email: string) => {
+    if (!hasSupabaseConfig) return
+    await getSupabase().auth.signInWithOtp({ email })
+  }
+
+  const signOut = async () => {
+    if (!hasSupabaseConfig) return
+    await getSupabase().auth.signOut()
+  }
+
+  return (
+    <AuthCtx.Provider value={{ user, loading, enabled: hasSupabaseConfig, signInWithOtp, signOut }}>
+      {children}
+    </AuthCtx.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthCtx)

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,16 +1,22 @@
-// web/src/lib/supabase.ts
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-const url  = import.meta.env.VITE_SUPABASE_URL
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY
+const URL = import.meta.env.VITE_SUPABASE_URL
+const KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-// Only create the client if both env vars exist.
-// This avoids the "supabaseUrl is required" crash on first paint.
-export const supabase: SupabaseClient | null =
-  url && anon ? createClient(url, anon) : null
+export const hasSupabaseConfig = Boolean(URL && KEY)
 
-// Helper you can use in code paths that truly require Supabase.
-export function requireSupabase(): SupabaseClient {
-  if (!supabase) throw new Error('Supabase not configured')
-  return supabase
+let _client: SupabaseClient | null = null
+
+/** Returns a Supabase client or throws if env isn’t configured. */
+export function getSupabase(): SupabaseClient {
+  if (!hasSupabaseConfig) {
+    throw new Error('Supabase not configured (set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY)')
+  }
+  if (!_client) _client = createClient(URL!, KEY!)
+  return _client
+}
+
+/** Optional soft accessor if you want to feature-gate on env presence. */
+export function maybeSupabase(): SupabaseClient | null {
+  return hasSupabaseConfig ? getSupabase() : null
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,16 +1,54 @@
-import { supabase } from '@/lib/supabase'
+import { useState } from 'react'
+import { hasSupabaseConfig, getSupabase } from '@/lib/supabase'
 
-export default function Login(){
-  const signIn = async () => {
-    const { error } = await supabase.auth.signInWithOtp({ email: (document.getElementById('email') as HTMLInputElement).value })
-    if (error) alert(error.message)
-    else alert('Check your email for a magic link!')
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  if (!hasSupabaseConfig) {
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-bold mb-2">Login</h1>
+        <p className="opacity-80">
+          Auth is <strong>disabled</strong>. Add
+          <code className="mx-1">VITE_SUPABASE_URL</code> and
+          <code className="mx-1">VITE_SUPABASE_ANON_KEY</code> in Vercel env vars to enable it.
+        </p>
+      </main>
+    )
   }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setErr(null)
+    try {
+      await getSupabase().auth.signInWithOtp({ email })
+      setSent(true)
+    } catch (e: any) {
+      setErr(e?.message ?? 'Failed to send magic link')
+    }
+  }
+
   return (
-    <main className="container-padded py-10 max-w-lg">
+    <main className="p-6 max-w-md">
       <h1 className="text-2xl font-bold mb-4">Login</h1>
-      <input id="email" type="email" placeholder="you@example.com" className="w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2" />
-      <button onClick={signIn} className="btn mt-3 w-full">Send magic link</button>
+      {sent ? (
+        <p>Check your inbox for a magic link.</p>
+      ) : (
+        <form onSubmit={submit} className="space-y-3">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-xl border border-white/15 bg-white/10 px-3 py-2"
+            placeholder="you@example.com"
+          />
+          <button className="btn" type="submit">Send magic link</button>
+          {err && <p className="text-red-400 text-sm">{err}</p>}
+        </form>
+      )}
     </main>
   )
 }

--- a/web/src/pages/Profile.tsx
+++ b/web/src/pages/Profile.tsx
@@ -1,13 +1,28 @@
-import { useAuth } from '@/lib/auth'
-import { supabase } from '@/lib/supabase'
+import { useEffect, useState } from 'react'
+import { hasSupabaseConfig, getSupabase } from '@/lib/supabase'
 
-export default function Profile(){
-  const { user } = useAuth()
+export default function Profile() {
+  const [email, setEmail] = useState<string | null>(null)
+
+  if (!hasSupabaseConfig) {
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-bold mb-2">Profile</h1>
+        <p className="opacity-80">Auth is disabled. Add Supabase env vars to enable profile data.</p>
+      </main>
+    )
+  }
+
+  useEffect(() => {
+    getSupabase().auth.getUser().then(({ data }) => {
+      setEmail(data.user?.email ?? null)
+    })
+  }, [])
+
   return (
-    <main className="container-padded py-10">
-      <h1 className="text-2xl font-bold mb-2">Profile</h1>
-      <div className="text-slate-300">{user?.email}</div>
-      <button className="btn-muted mt-4" onClick={() => supabase.auth.signOut()}>Sign out</button>
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Profile</h1>
+      {email ? <p>Signed in as <strong>{email}</strong></p> : <p>Not signed in.</p>}
     </main>
   )
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,24 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
-import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
-  plugins: [react(), VitePWA({
-    registerType: 'autoUpdate',
-    includeAssets: ['favicon.svg', 'og.png'],
-    manifest: {
-      name: 'Fynix',
-      short_name: 'Fynix',
-      theme_color: '#0b0f1f',
-      background_color: '#0b0f1f',
-      display: 'standalone',
-      icons: [
-        { src: '/favicon.svg', sizes: '192x192', type: 'image/svg+xml', purpose: 'any maskable' },
-        { src: '/favicon.svg', sizes: '512x512', type: 'image/svg+xml', purpose: 'any maskable' }
-      ]
-    }
-  })],
+  plugins: [react()],
   resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
   server: { port: 5173 },
   build: { sourcemap: true }


### PR DESCRIPTION
## Summary
- expose `getSupabase` getter and feature-gate auth flows when env vars are missing
- disable PWA plugin to avoid stale service worker issues

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac035af8e8832383c8972946746171