### PR TITLE
fix: add browser Buffer polyfills and rewrite blog loader

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,8 @@
     "posthog-js": "^1.166.0",
     "@supabase/supabase-js": "^2.48.1",
     "gray-matter": "^4.0.3",
-    "react-helmet-async": "^2.0.5"
+    "react-helmet-async": "^2.0.5",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
@@ -49,6 +50,7 @@
     "vite": "^5.2.0",
     "prettier": "^3.3.3",
     "vite-plugin-pwa": "^0.20.5",
-    "vitest": "^2.1.4"
+    "vitest": "^2.1.4",
+    "vite-plugin-node-polyfills": "^0.22.0"
   }
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,11 @@ import './sentry'
 import { initAnalytics } from './analytics'
 import { AuthProvider } from '@/lib/auth'
 
+// --- Browser polyfill for Node's Buffer (needed by some md libs)
+import { Buffer } from 'buffer'
+;(window as any).Buffer ??= Buffer
+// ---
+
 initAnalytics()
 
 createRoot(document.getElementById('root')!).render(

--- a/web/src/pages/Blog.tsx
+++ b/web/src/pages/Blog.tsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router-dom'
 import Seo from '@/seo/Seo'
-import { posts } from '@/lib/blog'
+import { getAllPosts } from '@/lib/blog'
 
-export default function Blog(){
+export default function Blog() {
+  const posts = getAllPosts()
   return (
     <main className="container-padded py-10">
       <Seo title="Blog" description="Insights and tactics for financial transformation." />
@@ -11,8 +12,8 @@ export default function Blog(){
         {posts.map(p => (
           <article key={p.slug} className="card p-6">
             <h2 className="text-xl font-semibold"><Link to={`/blog/${p.slug}`}>{p.title}</Link></h2>
-            <div className="text-slate-400 text-sm">{new Date(p.date).toLocaleDateString()}</div>
-            <p className="text-slate-300 mt-1">{p.description}</p>
+            <div className="text-slate-400 text-sm">{p.date ? new Date(p.date).toLocaleDateString() : ''}</div>
+            <p className="text-slate-300 mt-1">{p.excerpt}</p>
             <Link className="btn-muted mt-3 inline-flex" to={`/blog/${p.slug}`}>Read →</Link>
           </article>
         ))}

--- a/web/src/pages/BlogPost.tsx
+++ b/web/src/pages/BlogPost.tsx
@@ -2,17 +2,17 @@ import { useParams } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Seo from '@/seo/Seo'
-import { posts } from '@/lib/blog'
+import { getAllPosts } from '@/lib/blog'
 
 export default function BlogPost(){
   const { slug } = useParams()
-  const post = posts.find(p => p.slug === slug)
+  const post = getAllPosts().find(p => p.slug === slug)
   if (!post) return <main className="container-padded py-10">Not Found</main>
   return (
     <main className="container-padded py-10">
-      <Seo title={post.title} description={post.description} />
+      <Seo title={post.title} description={post.excerpt} />
       <h1 className="text-3xl font-bold">{post.title}</h1>
-      <div className="text-slate-400 text-sm mb-4">{new Date(post.date).toLocaleDateString()}</div>
+      <div className="text-slate-400 text-sm mb-4">{post.date ? new Date(post.date).toLocaleDateString() : ''}</div>
       <article className="prose prose-invert max-w-none">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
       </article>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 export default defineConfig({
-  plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
-  server: { port: 5173 },
+  plugins: [
+    react(),
+    nodePolyfills({
+      protocolImports: true, // enables `node:buffer` etc
+      include: ['buffer', 'process']
+    })
+  ],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      buffer: 'buffer' // allow `import { Buffer } from "buffer"`
+    }
+  },
+  define: {
+    // some libs look for process.env in browser
+    'process.env': {}
+  },
   build: { sourcemap: true }
 })


### PR DESCRIPTION
## Summary
- add `buffer` dependency and node polyfill plugin
- configure Vite to use node polyfills and expose `Buffer`
- polyfill `Buffer` at runtime and rewrite blog loader to parse raw markdown
- update blog pages to use `getAllPosts`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53ea8f9c8323b325469d1d9f71df