### PR TITLE
fix: align Fynix branding and Phoenix route

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,19 +4,36 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/favicon.svg" />
-    <title>Fynix</title>
+    <title>Fynix — From ashes to assets</title>
     <meta name="theme-color" content="#0b0f1f" />
-    <meta name="description" content="Fynix — From ashes to assets. A modern path to financial stability, recovery, and growth." />
-    <meta property="og:title" content="Fynix" />
-    <meta property="og:description" content="From ashes to assets — calculators and guides for financial transformation." />
+    <meta
+      name="description"
+      content="Fynix — From ashes to assets. A modern path to financial stability, recovery, and growth."
+    />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Fynix — From ashes to assets" />
+    <meta property="og:description" content="Calculators and guides for financial transformation." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/favicon.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <meta property="og:image" content="https://i.imgur.com/cQvZPEm.png" />
+    <meta property="og:image:alt" content="Fynix logo" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Fynix — From ashes to assets" />
+    <meta name="twitter:description" content="Calculators and guides for financial transformation." />
+    <meta name="twitter:image" content="https://i.imgur.com/cQvZPEm.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Link, Route, Routes } from 'react-router-dom'
+import { Link, Route, Routes, Navigate } from 'react-router-dom'
 import Home from '@/pages/Home'
 import Dashboard from '@/pages/Dashboard'
 import Login from '@/pages/Login'
@@ -14,7 +14,6 @@ import Pricing from '@/pages/Pricing'
 import Blog from '@/pages/Blog'
 import BlogPost from '@/pages/BlogPost'
 import Billing from '@/pages/Billing'
-import { Flame } from 'lucide-react'
 
 export default function App() {
   return (
@@ -22,7 +21,14 @@ export default function App() {
       <header className="sticky top-0 z-20 backdrop-blur border-b border-white/10">
         <div className="container-padded flex h-14 items-center justify-between">
           <Link to="/" className="flex items-center gap-2 font-extrabold tracking-tight">
-            <Flame className="h-5 w-5 text-amber-300" /> Fynix
+            <img
+              src="https://i.imgur.com/cQvZPEm.png"
+              alt="Fynix logo"
+              className="h-5 w-auto select-none"
+              loading="eager"
+              decoding="async"
+            />
+            Fynix
           </Link>
           <nav className="flex gap-2">
             <Link className="btn-muted" to="/">Home</Link>
@@ -30,7 +36,7 @@ export default function App() {
             <Link className="btn-muted" to="/docs">Docs</Link>
             <Link className="btn-muted" to="/tools">Tools</Link>
             <Link className="btn-muted" to="/onboarding">Onboarding</Link>
-            <Link className="btn-muted" to="/phoenix">Phoenix</Link>
+            <Link className="btn-muted" to="/fynix-daily">Fynix Daily</Link>
             <Link className="btn-muted" to="/pricing">Pricing</Link>
             <Link className="btn-muted" to="/blog">Blog</Link>
             <Link className="btn-muted" to="/about">About</Link>
@@ -49,7 +55,8 @@ export default function App() {
         <Route path="/docs/:slug" element={<Docs />} />
         <Route path="/tools" element={<Tools />} />
         <Route path="/onboarding" element={<Onboarding />} />
-        <Route path="/phoenix" element={<Phoenix />} />
+        <Route path="/fynix-daily" element={<Phoenix />} />
+        <Route path="/phoenix" element={<Navigate to="/fynix-daily" replace />} />
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/blog" element={<Blog />} />
         <Route path="/blog/:slug" element={<BlogPost />} />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 const resources = [
   {
-    title: 'The Phoenix Plan: A Strategic Guide to Financial Recovery, Credit Dominance, and Wealth Creation',
+    title: 'The Fynix Plan: A Strategic Guide to Financial Recovery, Credit Dominance, and Wealth Creation',
     description: 'Stabilize cash flow, counter wage garnishment, and build a resilient foundation.',
     to: '/docs/financial-planning-for-difficult-situations'
   },

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -14,7 +14,7 @@ export default function Home(){
           </motion.h1>
           <p className="mt-3 text-slate-300 max-w-2xl mx-auto">Practical calculators and step‑by‑step guides that help you stabilize, recover, and build wealth — without the fluff.</p>
           <div className="mt-7 flex items-center justify-center gap-3">
-            <button className="btn" onClick={() => navigate('/phoenix')}>Open Phoenix</button>
+            <button className="btn" onClick={() => navigate('/fynix-daily')}>Open Fynix Daily</button>
             <Link className="btn-muted" to="/docs">Browse Guides</Link>
           </div>
         </section>

--- a/web/src/pages/Phoenix.tsx
+++ b/web/src/pages/Phoenix.tsx
@@ -64,7 +64,7 @@ export default function Phoenix(){
     <main className="container-padded py-8 space-y-8">
       <section className="text-center">
         <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight bg-gradient-to-r from-white via-amber-200 to-brand-500 bg-clip-text text-transparent inline-flex items-center gap-2">
-          <Flame className="h-8 w-8 text-amber-300"/> Phoenix Daily
+          <Flame className="h-8 w-8 text-amber-300"/> Fynix Daily
         </h1>
         <p className="text-slate-300 mt-2">Your command center for income, budget, debt payoff, and growth.</p>
         <div className="mt-4 flex justify-center gap-2">

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -12,7 +12,7 @@ export default function Pricing(){
         <div className="card p-6">
           <div className="text-lg font-semibold">Free</div>
           <ul className="text-slate-300 list-disc list-inside mt-2">
-            <li>Phoenix tools (local)</li>
+            <li>Fynix Daily tools (local)</li>
             <li>Core guides</li>
             <li>Installable PWA</li>
           </ul>


### PR DESCRIPTION
## Summary
- set site-wide OG/Twitter image and metadata
- rebrand navigation and routes to "Fynix Daily" while redirecting `/phoenix`
- update budgeting page heading and related references

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9635f988323aa8c00bd55f990bd