### PR TITLE
Add dashboard KPI row and stats hook

### DIFF
--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,2 +1,7 @@
 export const fmt = (n: number) => n.toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
 export const pct = (n: number) => (isFinite(n) ? n.toFixed(0) + '%' : '—')
+
+export const asUSD = (n: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+
+export const asPct0 = (n: number) => `${Math.round(n * 100)}%`

--- a/web/src/lib/useDashboardStats.ts
+++ b/web/src/lib/useDashboardStats.ts
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from 'react'
+
+/**
+ * Where Phoenix writes the running summary (added below).
+ * { monthlyIncome: number, monthlyExpenses: number }
+ */
+const DASHBOARD_KEY = 'fynix.dashboard.summary'
+
+/** Payday rules (configurable; default = semi-monthly on 1 & 15). */
+export type PaydayRule =
+  | { type: 'weekly'; weekday: 0 | 1 | 2 | 3 | 4 | 5 | 6 }
+  | { type: 'biweekly'; startDate: string }
+  | { type: 'semiMonthly'; days: [number, number] }
+  | { type: 'monthly'; day: number }
+
+const PAYDAY_KEY = 'fynix.payday.rule'
+
+function readJSON<T>(key: string): T | null {
+  try {
+    return JSON.parse(localStorage.getItem(key) || 'null') as T | null
+  } catch {
+    return null
+  }
+}
+function writeJSON<T>(key: string, value: T) {
+  localStorage.setItem(key, JSON.stringify(value))
+}
+
+function startOfDay(d: Date) {
+  const x = new Date(d)
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+function addDays(d: Date, n: number) {
+  const x = new Date(d)
+  x.setDate(x.getDate() + n)
+  return x
+}
+
+function nextWeekly(now: Date, weekday: number) {
+  const n = now.getDay()
+  const delta = ((weekday - n + 7) % 7) || 7
+  return addDays(startOfDay(now), delta)
+}
+function nextBiweekly(now: Date, startISO: string) {
+  const start = startOfDay(new Date(startISO))
+  const ms14 = 14 * 86400000
+  let t = start.getTime()
+  const nowT = now.getTime()
+  while (t <= nowT) t += ms14
+  return new Date(t)
+}
+function nextSemiMonthly(now: Date, [a, b]: [number, number]) {
+  const d = now.getDate()
+  const [first, second] = a < b ? [a, b] : [b, a]
+  const y = now.getFullYear(), m = now.getMonth()
+  if (d < first) return new Date(y, m, first)
+  if (d < second) return new Date(y, m, second)
+  return new Date(y, m + 1, first)
+}
+function nextMonthly(now: Date, day: number) {
+  const y = now.getFullYear(), m = now.getMonth()
+  const d = now.getDate()
+  return d < day ? new Date(y, m, day) : new Date(y, m + 1, day)
+}
+
+function computeNextPayday(rule: PaydayRule, now = new Date()): Date {
+  switch (rule.type) {
+    case 'weekly':
+      return nextWeekly(now, rule.weekday)
+    case 'biweekly':
+      return nextBiweekly(now, rule.startDate)
+    case 'semiMonthly':
+      return nextSemiMonthly(now, rule.days)
+    case 'monthly':
+      return nextMonthly(now, rule.day)
+  }
+}
+
+export type DashboardStats = {
+  monthlyIncome: number
+  monthlyExpenses: number
+  budgetBalance: number
+  savingsRate: number
+  nextPaydayISO: string
+  paydayRule: PaydayRule
+  setPaydayRule: (r: PaydayRule) => void
+}
+
+const defaultRule: PaydayRule = { type: 'semiMonthly', days: [1, 15] }
+
+export function useDashboardStats(): DashboardStats {
+  const [summary, setSummary] = useState<{ monthlyIncome: number; monthlyExpenses: number } | null>(() =>
+    readJSON(DASHBOARD_KEY)
+  )
+  const [rule, setRule] = useState<PaydayRule>(() => readJSON<PaydayRule>(PAYDAY_KEY) ?? defaultRule)
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === DASHBOARD_KEY) setSummary(readJSON(DASHBOARD_KEY))
+      if (e.key === PAYDAY_KEY) setRule(readJSON(PAYDAY_KEY) ?? defaultRule)
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
+
+  const setPaydayRule = (r: PaydayRule) => {
+    writeJSON(PAYDAY_KEY, r)
+    setRule(r)
+  }
+
+  const stats = useMemo(() => {
+    const inc = Math.max(0, summary?.monthlyIncome ?? 0)
+    const exp = Math.max(0, summary?.monthlyExpenses ?? 0)
+    const bal = inc - exp
+    const rate = inc > 0 ? bal / inc : 0
+    const next = computeNextPayday(rule)
+    return {
+      monthlyIncome: inc,
+      monthlyExpenses: exp,
+      budgetBalance: bal,
+      savingsRate: rate,
+      nextPaydayISO: next.toISOString(),
+      paydayRule: rule,
+      setPaydayRule
+    }
+  }, [summary, rule])
+
+  return stats
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,31 +1,92 @@
 import { Link } from 'react-router-dom'
+import { asUSD, asPct0 } from '@/lib/format'
+import { useDashboardStats } from '@/lib/useDashboardStats'
+import { CalendarDays, PiggyBank, Wallet } from 'lucide-react'
 
 const resources = [
   {
-    title: 'The Fynix Plan: A Strategic Guide to Financial Recovery, Credit Dominance, and Wealth Creation',
-    description: 'Stabilize cash flow, counter wage garnishment, and build a resilient foundation.',
+    title:
+      'The Fynix Plan: A Strategic Guide to Financial Recovery, Credit Dominance, and Wealth Creation',
+    description:
+      'Stabilize cash flow, counter wage garnishment, and build a resilient foundation.',
     to: '/docs/financial-planning-for-difficult-situations'
   },
   {
-    title: 'The Architecture of Financial Transformation: Stability, Growth, and Personal Success',
-    description: 'Comprehensive blueprint for order, debt elimination, and long‑term wealth.',
+    title:
+      'The Architecture of Financial Transformation: Stability, Growth, and Personal Success',
+    description: 'Order, debt elimination, and long-term wealth.',
     to: '/docs/financial-recovery-and-credit-rebuilding'
   }
 ]
 
-export default function Dashboard(){
+export default function Dashboard() {
+  const { monthlyIncome, monthlyExpenses, budgetBalance, savingsRate, nextPaydayISO } =
+    useDashboardStats()
+  const nextPayday = new Date(nextPaydayISO).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  })
+
   return (
-    <main className="container-padded py-8">
-      <h1 className="text-3xl font-bold mb-6">Dashboard</h1>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {resources.map(r => (
-          <Link key={r.title} to={r.to} className="card p-6 hover:shadow-xl transition">
-            <h2 className="text-lg font-semibold">{r.title}</h2>
-            <p className="text-sm text-slate-300 mt-1">{r.description}</p>
-            <div className="mt-3 text-amber-200">Open →</div>
-          </Link>
+    <main className="container-padded py-8 space-y-8">
+      <header className="flex items-end justify-between">
+        <h1 className="text-3xl font-extrabold tracking-tight">Dashboard</h1>
+      </header>
+
+      {/* KPI ROW */}
+      <section className="grid gap-4 sm:grid-cols-3">
+        <KPI
+          icon={<Wallet className="h-5 w-5" />}
+          label="Budget Balance"
+          value={asUSD(budgetBalance)}
+          sub={budgetBalance >= 0 ? 'Surplus' : 'Deficit'}
+        />
+        <KPI
+          icon={<PiggyBank className="h-5 w-5" />}
+          label="Savings Rate"
+          value={asPct0(savingsRate)}
+          sub={`${asUSD(monthlyIncome - monthlyExpenses)} / ${asUSD(monthlyIncome)}`}
+        />
+        <KPI
+          icon={<CalendarDays className="h-5 w-5" />}
+          label="Next Payday"
+          value={nextPayday}
+          sub="Configured in settings (default 1st & 15th)"
+        />
+      </section>
+
+      {/* CONTENT CARDS */}
+      <section className="grid gap-4 sm:grid-cols-2">
+        {resources.map((r) => (
+          <article key={r.title} className="card p-6 hover:shadow-md transition-shadow">
+            <h2 className="font-semibold leading-tight">{r.title}</h2>
+            <p className="mt-2 text-sm text-white/75">{r.description}</p>
+            <Link
+              to={r.to}
+              className="mt-3 inline-flex items-center gap-2 text-amber-300 hover:underline"
+            >
+              Open →
+            </Link>
+          </article>
         ))}
-      </div>
+      </section>
     </main>
+  )
+}
+
+function KPI(props: { icon: React.ReactNode; label: string; value: string; sub?: string }) {
+  const { icon, label, value, sub } = props
+  return (
+    <div className="card px-5 py-4 flex items-center gap-4">
+      <div className="grid place-items-center h-10 w-10 rounded-xl bg-white/10 shrink-0">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <div className="text-xs uppercase tracking-wide text-white/60">{label}</div>
+        <div className="text-xl font-semibold">{value}</div>
+        {sub && <div className="text-xs text-white/60">{sub}</div>}
+      </div>
+    </div>
   )
 }

--- a/web/src/pages/Phoenix.tsx
+++ b/web/src/pages/Phoenix.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, useEffect } from 'react'
 import { Button, ButtonMuted } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Field, Input } from '@/components/ui/Field'
@@ -55,6 +55,11 @@ export default function Phoenix(){
   const incRef = useRef<HTMLInputElement>(null)
   const catRef = useRef<HTMLInputElement>(null)
   const expRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const summary = { monthlyIncome: totalIncome, monthlyExpenses: totalExpenses }
+    localStorage.setItem('fynix.dashboard.summary', JSON.stringify(summary))
+  }, [totalIncome, totalExpenses])
 
   const addIncome = () => { const name = nameRef.current?.value?.trim() || 'Income'; const amount = Number(incRef.current?.value || 0); if (!amount) return; setIncomes(v => [...v, { id: crypto.randomUUID(), name, amount }]); if (nameRef.current) nameRef.current.value = ''; if (incRef.current) incRef.current.value = '' }
   const addExpense = () => { const category = catRef.current?.value?.trim() || 'Expense'; const amount = Number(expRef.current?.value || 0); if (!amount) return; setExpenses(v => [...v, { id: crypto.randomUUID(), category, amount }]); if (catRef.current) catRef.current.value = ''; if (expRef.current) expRef.current.value = '' }


### PR DESCRIPTION
## Summary
- introduce `useDashboardStats` hook to compute budget balance, savings rate, and next payday from Phoenix data
- persist income and expense summary from Phoenix to feed dashboard stats
- show KPI row on Dashboard with formatted amounts and icons

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68af3f53f3cc832391dffae8c54ef1d7