### PR TITLE
fix: add SPA fallback for docs routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,9 @@
   "installCommand": "npm --prefix web i",
   "buildCommand": "npm --prefix web run build",
   "outputDirectory": "web/dist",
-  "framework": "vite"
+  "framework": "vite",
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,7 @@ export default function App() {
         <Route path="/billing" element={<Billing />} />
         <Route path="/login" element={<Login />} />
         <Route path="/profile" element={<Protected><Profile /></Protected>} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </div>
   )


### PR DESCRIPTION
## Summary
- ensure Vercel rewrites unknown routes to index.html for React Router
- add wildcard route to redirect unknown paths to home

## Testing
- `npm --prefix web test`
- `npm --prefix web run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68af482348588323a9b117f394bc8b8b